### PR TITLE
Github Actions 자바 버전 1.8 인식 못하는 문제

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3.12.0
         with:
-          java-version: '1.8' 
+          java-version: '8' 
           distribution: 'temurin'
         # JDK 8 설치 및 설정
 


### PR DESCRIPTION
## 작업 내용
- 자바 버전을 1.8 -> 8로 명시


